### PR TITLE
feat: integrate OpenRouter provider with selectable models

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Codex CLI supports [MCP servers](./docs/advanced.md#model-context-protocol-mcp).
 
 Codex CLI supports a rich set of configuration options, with preferences stored in `~/.codex/config.toml`. For full configuration options, see [Configuration](./docs/config.md).
 
+To use models from [OpenRouter](https://openrouter.ai), add a `[model_providers.openrouter]` section with a `models` list in `config.toml`, launch the CLI with `--provider openrouter`, and switch between those models at runtime with the `/models` command.
+
 ---
 
 ### Docs & FAQ

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -344,6 +344,29 @@ pub fn set_project_trusted(codex_home: &Path, project_path: &Path) -> anyhow::Re
     Ok(())
 }
 
+/// Persist an API key for the given model provider in `config.toml`.
+pub fn set_model_provider_api_key(
+    codex_home: &Path,
+    provider_id: &str,
+    api_key: &str,
+) -> anyhow::Result<()> {
+    let config_path = codex_home.join(CONFIG_TOML_FILE);
+    // Parse existing config if present; otherwise start a new document.
+    let mut doc = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s.parse::<DocumentMut>()?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => DocumentMut::new(),
+        Err(e) => return Err(e.into()),
+    };
+
+    doc["model_providers"][provider_id]["api_key"] = toml_edit::value(api_key);
+
+    std::fs::create_dir_all(codex_home)?;
+    let tmp_file = NamedTempFile::new_in(codex_home)?;
+    std::fs::write(tmp_file.path(), doc.to_string())?;
+    tmp_file.persist(config_path)?;
+    Ok(())
+}
+
 /// Apply a single dotted-path override onto a TOML value.
 fn apply_toml_override(root: &mut TomlValue, path: &str, value: TomlValue) {
     use toml::value::Table;
@@ -654,7 +677,7 @@ impl Config {
         let mut model_providers = built_in_model_providers();
         // Merge user-defined providers into the built-in list.
         for (key, provider) in cfg.model_providers.into_iter() {
-            model_providers.entry(key).or_insert(provider);
+            model_providers.insert(key, provider);
         }
 
         let model_provider_id = model_provider

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -49,6 +49,9 @@ pub struct ModelProviderInfo {
     /// Environment variable that stores the user's API key for this provider.
     pub env_key: Option<String>,
 
+    /// API key to use for this provider (takes precedence over `env_key`).
+    pub api_key: Option<String>,
+
     /// Optional instructions to help the user get a valid value for the
     /// variable and set it.
     pub env_key_instructions: Option<String>,
@@ -83,6 +86,10 @@ pub struct ModelProviderInfo {
     /// Whether this provider requires some form of standard authentication (API key, ChatGPT token).
     #[serde(default)]
     pub requires_openai_auth: bool,
+
+    /// Optional list of models that can be selected for this provider.
+    #[serde(default)]
+    pub models: Option<Vec<String>>,
 }
 
 impl ModelProviderInfo {
@@ -185,6 +192,11 @@ impl ModelProviderInfo {
     /// (and non-empty) in the environment. If `env_key` is required but
     /// cannot be found, returns an error.
     pub fn api_key(&self) -> crate::error::Result<Option<String>> {
+        if let Some(key) = &self.api_key {
+            if !key.trim().is_empty() {
+                return Ok(Some(key.clone()));
+            }
+        }
         match &self.env_key {
             Some(env_key) => {
                 let env_value = std::env::var(env_key);
@@ -255,6 +267,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                     .ok()
                     .filter(|v| !v.trim().is_empty()),
                 env_key: None,
+                api_key: None,
                 env_key_instructions: None,
                 wire_api: WireApi::Responses,
                 query_params: None,
@@ -279,6 +292,36 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                 stream_max_retries: None,
                 stream_idle_timeout_ms: None,
                 requires_openai_auth: true,
+                models: None,
+            },
+        ),
+        (
+            "openrouter",
+            P {
+                name: "OpenRouter".into(),
+                base_url: Some("https://openrouter.ai/api/v1".into()),
+                env_key: Some("OPENROUTER_API_KEY".into()),
+                api_key: None,
+                env_key_instructions: Some("Get your API key at https://openrouter.ai/keys".into()),
+                wire_api: WireApi::Chat,
+                query_params: None,
+                http_headers: Some(
+                    [
+                        (
+                            "HTTP-Referer".to_string(),
+                            "https://github.com/openai/codex".to_string(),
+                        ),
+                        ("X-Title".to_string(), "Codex".to_string()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+                env_http_headers: None,
+                request_max_retries: None,
+                stream_max_retries: None,
+                stream_idle_timeout_ms: None,
+                requires_openai_auth: false,
+                models: None,
             },
         ),
         (BUILT_IN_OSS_MODEL_PROVIDER_ID, create_oss_provider()),
@@ -314,6 +357,7 @@ pub fn create_oss_provider_with_base_url(base_url: &str) -> ModelProviderInfo {
         name: "gpt-oss".into(),
         base_url: Some(base_url.into()),
         env_key: None,
+        api_key: None,
         env_key_instructions: None,
         wire_api: WireApi::Chat,
         query_params: None,
@@ -323,6 +367,7 @@ pub fn create_oss_provider_with_base_url(base_url: &str) -> ModelProviderInfo {
         stream_max_retries: None,
         stream_idle_timeout_ms: None,
         requires_openai_auth: false,
+        models: None,
     }
 }
 

--- a/codex-rs/exec/Cargo.toml
+++ b/codex-rs/exec/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1", features = [
 ] }
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+rpassword = "7"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -17,6 +17,10 @@ pub struct Cli {
     #[arg(long = "oss", default_value_t = false)]
     pub oss: bool,
 
+    /// Model provider id (e.g. "openai", "openrouter").
+    #[arg(long = "provider")]
+    pub provider: Option<String>,
+
     /// Select the sandbox policy to use when executing model-generated shell
     /// commands.
     #[arg(long = "sandbox", short = 's', value_enum)]

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -13,6 +13,7 @@ use codex_core::ConversationManager;
 use codex_core::NewConversation;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
+use codex_core::config::set_model_provider_api_key;
 use codex_core::protocol::AskForApproval;
 use codex_core::protocol::Event;
 use codex_core::protocol::EventMsg;
@@ -38,6 +39,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         images,
         model: model_cli_arg,
         oss,
+        provider,
         config_profile,
         full_auto,
         dangerously_bypass_approvals_and_sandbox,
@@ -131,7 +133,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
     let model_provider = if oss {
         Some(BUILT_IN_OSS_MODEL_PROVIDER_ID.to_string())
     } else {
-        None // No specific model provider override.
+        provider.clone()
     };
 
     // Load configuration and determine approval policy
@@ -162,7 +164,19 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         }
     };
 
-    let config = Config::load_with_cli_overrides(cli_kv_overrides, overrides)?;
+    let mut config = Config::load_with_cli_overrides(cli_kv_overrides, overrides)?;
+
+    if config.model_provider.env_key.is_some()
+        && config.model_provider.api_key().ok().flatten().is_none()
+    {
+        let prompt = format!("Enter API key for {}: ", config.model_provider.name);
+        let key = rpassword::prompt_password(prompt)?;
+        set_model_provider_api_key(&config.codex_home, &config.model_provider_id, &key)?;
+        config.model_provider.api_key = Some(key.clone());
+        if let Some(p) = config.model_providers.get_mut(&config.model_provider_id) {
+            p.api_key = Some(key);
+        }
+    }
     let mut event_processor: Box<dyn EventProcessor> = if json_mode {
         Box::new(EventProcessorWithJsonOutput::new(last_message_file.clone()))
     } else {

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -78,6 +78,7 @@ tokio = { version = "1", features = [
     "signal",
 ] }
 tokio-stream = "0.1.17"
+rpassword = "7"
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -785,7 +785,7 @@ impl ChatWidget {
                 self.clear_token_usage();
                 self.app_event_tx.send(AppEvent::CodexOp(Op::Compact));
             }
-            SlashCommand::Model => {
+            SlashCommand::Models => {
                 self.open_model_popup();
             }
             SlashCommand::Approvals => {
@@ -1074,9 +1074,42 @@ impl ChatWidget {
     pub(crate) fn open_model_popup(&mut self) {
         let current_model = self.config.model.clone();
         let current_effort = self.config.model_reasoning_effort;
-        let presets: &[ModelPreset] = builtin_model_presets();
 
         let mut items: Vec<SelectionItem> = Vec::new();
+        if let Some(models) = &self.config.model_provider.models {
+            for model_slug in models.iter() {
+                let name = model_slug.to_string();
+                let is_current = *model_slug == current_model;
+                let model_clone = model_slug.to_string();
+                let effort = current_effort;
+                let actions: Vec<SelectionAction> = vec![Box::new(move |tx| {
+                    tx.send(AppEvent::CodexOp(Op::OverrideTurnContext {
+                        cwd: None,
+                        approval_policy: None,
+                        sandbox_policy: None,
+                        model: Some(model_clone.clone()),
+                        effort: Some(effort),
+                        summary: None,
+                    }));
+                    tx.send(AppEvent::UpdateModel(model_clone.clone()));
+                })];
+                items.push(SelectionItem {
+                    name,
+                    description: None,
+                    is_current,
+                    actions,
+                });
+            }
+            self.bottom_pane.show_selection_view(
+                "Select model".to_string(),
+                Some("Choose model for this and future Codex CLI session".to_string()),
+                Some("Press Enter to confirm or Esc to go back".to_string()),
+                items,
+            );
+            return;
+        }
+
+        let presets: &[ModelPreset] = builtin_model_presets();
         for preset in presets.iter() {
             let name = preset.label.to_string();
             let description = Some(preset.description.to_string());

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -17,6 +17,10 @@ pub struct Cli {
     #[arg(long, short = 'm')]
     pub model: Option<String>,
 
+    /// Model provider id (e.g. "openai", "openrouter").
+    #[arg(long = "provider")]
+    pub provider: Option<String>,
+
     /// Convenience flag to select the local open source model provider.
     /// Equivalent to -c model_provider=oss; verifies a local Ollama server is
     /// running.

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -314,13 +314,13 @@ pub(crate) fn new_session_info(
             ]),
             Line::from(vec![
                 Span::styled(
-                    " /model",
+                    " /models",
                     Style::default()
                         .add_modifier(Modifier::BOLD)
                         .fg(Color::White),
                 ),
                 Span::styled(
-                    format!(" - {}", SlashCommand::Model.description()),
+                    format!(" - {}", SlashCommand::Models.description()),
                     Style::default().dim(),
                 ),
             ]),

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -10,6 +10,7 @@ use codex_core::config::ConfigOverrides;
 use codex_core::config::ConfigToml;
 use codex_core::config::find_codex_home;
 use codex_core::config::load_config_as_toml_with_cli_overrides;
+use codex_core::config::set_model_provider_api_key;
 use codex_core::protocol::AskForApproval;
 use codex_core::protocol::SandboxPolicy;
 use codex_login::AuthManager;
@@ -109,7 +110,7 @@ pub async fn run_main(
     let model_provider_override = if cli.oss {
         Some(BUILT_IN_OSS_MODEL_PROVIDER_ID.to_owned())
     } else {
-        None
+        cli.provider.clone()
     };
 
     // canonicalize the cwd
@@ -154,6 +155,32 @@ pub async fn run_main(
             }
         }
     };
+
+    if config.model_provider.env_key.is_some()
+        && config.model_provider.api_key().ok().flatten().is_none()
+    {
+        #[allow(clippy::print_stderr)]
+        {
+            let prompt = format!("Enter API key for {}: ", config.model_provider.name);
+            match rpassword::prompt_password(prompt) {
+                Ok(key) => {
+                    if let Err(e) = set_model_provider_api_key(
+                        &config.codex_home,
+                        &config.model_provider_id,
+                        &key,
+                    ) {
+                        eprintln!("Failed to store API key: {e}");
+                    } else {
+                        config.model_provider.api_key = Some(key.clone());
+                        if let Some(p) = config.model_providers.get_mut(&config.model_provider_id) {
+                            p.api_key = Some(key);
+                        }
+                    }
+                }
+                Err(e) => eprintln!("Failed to read API key: {e}"),
+            }
+        }
+    }
 
     // we load config.toml here to determine project state.
     #[allow(clippy::print_stderr)]

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -12,7 +12,7 @@ use strum_macros::IntoStaticStr;
 pub enum SlashCommand {
     // DO NOT ALPHA-SORT! Enum order is presentation order in the popup, so
     // more frequently used commands should be listed first.
-    Model,
+    Models,
     Approvals,
     New,
     Init,
@@ -38,7 +38,7 @@ impl SlashCommand {
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Mention => "mention a file",
             SlashCommand::Status => "show current session configuration and token usage",
-            SlashCommand::Model => "choose what model and reasoning effort to use",
+            SlashCommand::Models => "choose what model and reasoning effort to use",
             SlashCommand::Approvals => "choose what Codex can do without approval",
             SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Logout => "log out of Codex",
@@ -59,7 +59,7 @@ impl SlashCommand {
             SlashCommand::New
             | SlashCommand::Init
             | SlashCommand::Compact
-            | SlashCommand::Model
+            | SlashCommand::Models
             | SlashCommand::Approvals
             | SlashCommand::Logout => false,
             SlashCommand::Diff

--- a/codex-rs/tui/tests/fixtures/ideal-binary-response.txt
+++ b/codex-rs/tui/tests/fixtures/ideal-binary-response.txt
@@ -3,7 +3,7 @@ To get started, describe a task or try one of these commands:
  /init - create an AGENTS.md file with instructions for Codex
  /status - show current session configuration and token usage
  /approvals - choose what Codex can do without approval
- /model - choose what model and reasoning effort to use
+ /models - choose what model and reasoning effort to use
 
 codex
 I’m going to scan the workspace and Cargo manifests to see build profiles and

--- a/docs/config.md
+++ b/docs/config.md
@@ -92,6 +92,16 @@ http_headers = { "X-Example-Header" = "example-value" }
 # _if_ the environment variable is set and its value is non-empty.
 env_http_headers = { "X-Example-Features": "EXAMPLE_FEATURES" }
 ```
+```toml
+[model_providers.openrouter]
+name = "OpenRouter"
+base_url = "https://openrouter.ai/api/v1"
+env_key = "OPENROUTER_API_KEY"
+http_headers = { "HTTP-Referer" = "https://github.com/openai/codex", "X-Title" = "Codex" }
+models = ["openai/gpt-4o-mini", "anthropic/claude-3"]
+```
+
+Run the CLI with `--provider openrouter` and use the `/models` command to pick one of the entries listed above.
 
 ### Per-provider network tuning
 
@@ -587,10 +597,12 @@ Options that are specific to the TUI.
 | `model_providers.<id>.name` | string | Display name. |
 | `model_providers.<id>.base_url` | string | API base URL. |
 | `model_providers.<id>.env_key` | string | Env var for API key. |
+| `model_providers.<id>.api_key` | string | API key stored in config. |
 | `model_providers.<id>.wire_api` | `chat` | `responses` | Protocol used (default: `chat`). |
 | `model_providers.<id>.query_params` | map<string,string> | Extra query params (e.g., Azure `api-version`). |
 | `model_providers.<id>.http_headers` | map<string,string> | Additional static headers. |
 | `model_providers.<id>.env_http_headers` | map<string,string> | Headers sourced from env vars. |
+| `model_providers.<id>.models` | array<string> | Allowed model ids for `/models` selection. |
 | `model_providers.<id>.request_max_retries` | number | Per‑provider HTTP retry count (default: 4). |
 | `model_providers.<id>.stream_max_retries` | number | SSE stream retry count (default: 5). |
 | `model_providers.<id>.stream_idle_timeout_ms` | number | SSE idle timeout (ms) (default: 300000). |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ In 2021, OpenAI released Codex, an AI system designed to generate code from natu
 
 ### Which models are supported?
 
-We recommend using Codex with GPT-5, our best coding model. The default reasoning level is medium, and you can upgrade to high for complex tasks with the `/model` command.
+We recommend using Codex with GPT-5, our best coding model. The default reasoning level is medium, and you can upgrade to high for complex tasks with the `/models` command.
 
 You can also use older models by using API-based auth and launching codex with the `--model` flag.
 


### PR DESCRIPTION
## Summary
- add built-in OpenRouter provider with required headers and API key support
- allow selecting model provider via `--provider` flag, persisting API keys on first use
- support `/models` command to switch between provider models defined in config
- document OpenRouter configuration and editable model list

## Testing
- `cargo fmt`
- `cargo clippy -p codex-core --no-deps` *(fails: failed to get `ansi-to-tui` as a dependency of package `codex-ansi-escape v0.0.0`)*
- `cargo clippy -p codex-exec --no-deps` *(fails: failed to get `ansi-to-tui` as a dependency of package `codex-ansi-escape v0.0.0`)*
- `cargo clippy -p codex-tui --no-deps` *(fails: failed to get `ansi-to-tui` as a dependency of package `codex-ansi-escape v0.0.0`)*
- `cargo test -p codex-core` *(fails: failed to get `ansi-to-tui` as a dependency of package `codex-ansi-escape v0.0.0`)*
- `cargo test -p codex-exec` *(fails: failed to get `ansi-to-tui` as a dependency of package `codex-ansi-escape v0.0.0`)*
- `cargo test -p codex-tui` *(fails: failed to get `ansi-to-tui` as a dependency of package `codex-ansi-escape v0.0.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68b204a5033c832cb372661fb4cf7054